### PR TITLE
Fixed path that images are moved to before upload.

### DIFF
--- a/src/api/samples/create.php
+++ b/src/api/samples/create.php
@@ -655,7 +655,7 @@ function forward_post_to($entity, $submission = NULL, $files = NULL, $writeToken
         }
         else {
           $success = rename(
-            $interim_image_folder.$item['path'],
+            data_entry_helper::getInterimImageFolder('fullpath') . $item['path'],
             $final_image_folder.$item['path']
           );
         }
@@ -699,7 +699,7 @@ function prepare_media_for_upload($files = []) {
     }
 
     $destination = $file['name'];
-    $uploadPath = data_entry_helper::getInterimImageFolder();
+    $uploadPath = data_entry_helper::getInterimImageFolder('fullpath');
 
     if (move_uploaded_file($file['tmp_name'], $uploadPath . $destination)) {
       $r[] = array(

--- a/src/api/samples/create.php
+++ b/src/api/samples/create.php
@@ -698,14 +698,10 @@ function prepare_media_for_upload($files = []) {
       data_entry_helper::$validation_errors[$key] = lang::get('file too big for warehouse');
     }
 
-
     $destination = $file['name'];
-    $interim_image_folder = isset(data_entry_helper::$interim_image_folder) ?
-      data_entry_helper::$interim_image_folder :
-      'upload/';
-    $uploadpath = data_entry_helper::relative_client_helper_path() . $interim_image_folder;
+    $uploadPath = data_entry_helper::getInterimImageFolder();
 
-    if (move_uploaded_file($file['tmp_name'], $uploadpath . $destination)) {
+    if (move_uploaded_file($file['tmp_name'], $uploadPath . $destination)) {
       $r[] = array(
         // Id is set only when saving over an existing record.
         // This will always be a new record.

--- a/src/api/samples/create.php
+++ b/src/api/samples/create.php
@@ -647,7 +647,7 @@ function forward_post_to($entity, $submission = NULL, $files = NULL, $writeToken
       if ((empty($item['media_type']) || preg_match('/:Local$/', $item['media_type'])) &&
         empty($item['id'])) {
         if (!isset(data_entry_helper::$final_image_folder) ||
-          data_entry_helper::$final_image_folder=='warehouse') {
+            data_entry_helper::$final_image_folder === 'warehouse') {
           // Final location is the Warehouse
           // @todo Set PERSIST_AUTH false if last file
           indicia_api_log('Uploading ' . $item['path']);
@@ -656,7 +656,7 @@ function forward_post_to($entity, $submission = NULL, $files = NULL, $writeToken
         else {
           $success = rename(
             data_entry_helper::getInterimImageFolder('fullpath') . $item['path'],
-            $final_image_folder.$item['path']
+            data_entry_helper::$final_image_folder.$item['path']
           );
         }
 


### PR DESCRIPTION
Calculation was including client helper path in path, but under D8 we now
use the files dir for temporary file storage.
Please enter the commit message for your changes. Lines starting